### PR TITLE
require attrs >= 19.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
     - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
 
 install:
+  - pip install --upgrade pytest
   # report the installed packages
   - pip freeze
   # Install this package and the packages listed in requirements.txt.

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
     - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
 
 install:
-  - pip install --upgrade pytest
   # report the installed packages
   - pip freeze
   # Install this package and the packages listed in requirements.txt.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 language: python
 python:
   - 3.6
+  - 3.7
 cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
 
 install:
+  # report the installed packages
+  - pip freeze
   # Install this package and the packages listed in requirements.txt.
   - pip install .
   # Install extra requirements for running tests and building docs.
   - pip install -r requirements-dev.txt
+  # report the installed packages
+  - pip freeze
 
 script:
   - coverage run -m pytest suitcase/utils/tests/tests.py  # Run the tests and check for test coverage.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
+attrs>=19.3.0
 bluesky
 caproto  # required in order to import ophyd test fixtures
 curio  # required in order to import ophyd test fixtures

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open(path.join(here, 'requirements.txt')) as requirements_file:
 
 
 extras_require = {
-    'test_fixtures': ['attrs >= 18.1.0', 'bluesky', 'caproto', 'curio',
+    'test_fixtures': ['attrs >= 19.3.0', 'bluesky', 'caproto', 'curio',
                       'ophyd', 'pytest >=3.9', 'trio']
 }
 


### PR DESCRIPTION
Only two changes: require attrs >= 19.3.0, and test with python 3.7 as well as 3.6.