### PR TITLE
Add size estimates to File and Memory Managers

### DIFF
--- a/suitcase/utils/__init__.py
+++ b/suitcase/utils/__init__.py
@@ -133,7 +133,7 @@ class MultiFileManager:
 
             def wrapped_close():
                 handler.seek(0, os.SEEK_END)
-                self._sizes[filepath] = handler.tell()
+                self._sizes[postfix] = handler.tell()
                 orig_close()
 
             handler.close = wrapped_close
@@ -142,7 +142,7 @@ class MultiFileManager:
         f = open(filepath, mode=mode, encoding=encoding, errors=errors)
         f = update_size_on_close(f)
 
-        self._sizes[filepath] = None
+        self._sizes[postfix] = None
         self._files.append(f)
 
         return f

--- a/suitcase/utils/__init__.py
+++ b/suitcase/utils/__init__.py
@@ -154,34 +154,6 @@ class MultiFileManager:
             f.close()
 
 
-class PersistentStringIO(io.StringIO):
-    ''' A StringIO that does not clear the buffer when closed.
-
-        .. note::
-
-            This StringIO subclass behaves like StringIO except that its
-            close() method, which would normally clear the buffer, has no
-            effect. The clear() method, however, may still be used.
-    '''
-    def close(self):
-        # Avoid clearing the buffer before caller of ``export`` can access it.
-        pass
-
-
-class PersistentBytesIO(io.BytesIO):
-    ''' A BytesIO that does not clear the buffer when closed.
-
-        .. note::
-
-            This BytesIO subclass behaves like BytesIO except that its
-            close() method, which would normally clear the buffer, has no
-            effect. The clear() method, however, may still be used.
-    '''
-    def close(self):
-        # Avoid clearing the buffer before caller of ``export`` can access it.
-        pass
-
-
 class MemoryBuffersManager:
     """
     A class that manages multiple StringIO and/or BytesIO instances.

--- a/suitcase/utils/__init__.py
+++ b/suitcase/utils/__init__.py
@@ -56,18 +56,21 @@ class Artifact:
         if handle is not None:
             self.handle = handle
 
-    def __iter__(self):
+    def to_dict(self):
         """
-        Make this class iterable.
+        Returns current values of properties as a dictionary.
 
-        Allows converting instances to a dict by casting: dict(myartifact)
+        Only ``handle`` is a mutable reference. Other values are snapshots
+        of current values at the time of calling this method.
         """
-        yield 'label', self.label
-        yield 'postfix', self.postfix
-        yield 'name', self.name
-        yield 'current_size', self.current_size
-        yield 'initial_size', self.initial_size
-        yield 'handle', self.handle
+        return {
+            'label': self.label,
+            'postfix': self.postfix,
+            'name': self.name,
+            'current_size': self.current_size,
+            'initial_size': self.initial_size,
+            'handle': self.handle,
+        }
 
     @property
     def handle(self):
@@ -160,7 +163,7 @@ class MultiFileManager:
             Optional. Filter returned list to include only artifacts that
             match the given label value.
         """
-        return [dict(a) for a in self._artifacts
+        return [a.to_dict() for a in self._artifacts
                 if label is None or a.label == label]
 
     def _get_artifact(self, postfix):
@@ -323,7 +326,7 @@ class MemoryBuffersManager:
             Optional. Filter returned list to include only artifacts that
             match the given label value.
         """
-        return [dict(a) for a in self._artifacts
+        return [a.to_dict() for a in self._artifacts
                 if label is None or a.label == label]
 
     def _get_artifact(self, postfix):

--- a/suitcase/utils/tests/tests.py
+++ b/suitcase/utils/tests/tests.py
@@ -33,6 +33,7 @@ def test_multifile_basic_operation(tmp_path):
     assert not f.closed
     manager.close()
     assert f.closed
+    assert 4 == manager.estimated_sizes[name1]
     with open(name1) as f:
         actual = f.read()
     assert actual == 'test'

--- a/suitcase/utils/tests/tests.py
+++ b/suitcase/utils/tests/tests.py
@@ -38,6 +38,8 @@ def test_multifile_basic_operation(tmp_path):
         actual = f.read()
     assert actual == 'test'
     assert [name1, name2] == manager.artifacts['thing']
+    assert 2 == len(manager.get_artifacts('thing'))
+    assert 'stuff' == manager.get_artifacts('thing')[0]['postfix']
 
     # Test append.
     manager = MultiFileManager(tmp_path)
@@ -82,6 +84,8 @@ def test_memory_buffers_basic_operation():
     actual = f.read()
     assert actual == 'test'
     assert [f] == manager.artifacts['thing']
+    assert 1 == len(manager.get_artifacts('thing'))
+    assert 'stuff' == manager.get_artifacts('thing')[0]['postfix']
 
 
 def test_fixture(example_data):

--- a/suitcase/utils/tests/tests.py
+++ b/suitcase/utils/tests/tests.py
@@ -77,6 +77,7 @@ def test_memory_buffers_basic_operation():
     assert not f.closed
     manager.close()
     assert not f.closed  # Close is a no-op on Persistent{String|Bytes}IO.
+    assert 4 == manager.estimated_sizes['stuff']
     f.seek(0)
     actual = f.read()
     assert actual == 'test'

--- a/suitcase/utils/tests/tests.py
+++ b/suitcase/utils/tests/tests.py
@@ -33,7 +33,7 @@ def test_multifile_basic_operation(tmp_path):
     assert not f.closed
     manager.close()
     assert f.closed
-    assert 4 == manager.estimated_sizes[name1]
+    assert 4 == manager.estimated_sizes['stuff']
     with open(name1) as f:
         actual = f.read()
     assert actual == 'test'


### PR DESCRIPTION
Closes #37 

As discussed offline, implemented a bit differently from original suggestion.

Adds an `estimated_sizes` property to the managers. Returns dictionary mapping postfix to total size of file/buffer. It is only populated with useful data once the handlers are closed.