### PR TITLE
Allow Artifact.handle to be closed more than once

### DIFF
--- a/suitcase/utils/__init__.py
+++ b/suitcase/utils/__init__.py
@@ -92,6 +92,9 @@ class Artifact:
             def wrapped_close():
                 handle.seek(0, os.SEEK_END)
                 self._final_size = handle.tell()
+                # Reset close method, so that it can be called again, doing nothing
+                # Otherwise handle.seek above raises an exception on the second call
+                handle.close = orig_close
                 orig_close()
 
             handle.close = wrapped_close


### PR DESCRIPTION
Normal file handles can have close() called more than once, although only the first call has any effect. Artifact replaces handle.close with wrapped_close, but wrapped_close can only be called once. On the second call, `handle.seek` raises a `ValueError`. This affects at least `suitcase-csv` and `suitcase-json-metadata`. If `wrapped_close` puts the original close method back, subsequent calls to close() will work properly (because they call the original method).

Closes #43